### PR TITLE
[FIX] 타이머 로직 시간 서버 측에서 관리하도록 수정사항 반영

### DIFF
--- a/lib/models/dto/study/end_study_request_dto.dart
+++ b/lib/models/dto/study/end_study_request_dto.dart
@@ -1,13 +1,11 @@
 class EndStudyRequestDto {
   final int studySessionId;
-  final DateTime endTime;
 
-  EndStudyRequestDto({required this.studySessionId, required this.endTime});
+  EndStudyRequestDto({required this.studySessionId});
 
   Map<String, dynamic> toJson() {
     return {
       "studySessionId": studySessionId.toString(),
-      "endTime": endTime.toIso8601String(),
     };
   }
 }

--- a/lib/models/dto/study/start_study_time_request_dto.dart
+++ b/lib/models/dto/study/start_study_time_request_dto.dart
@@ -1,17 +1,14 @@
 class StartStudyTimeRequestDto {
-  final DateTime startTime;
   final String gatewayIp;
   final String clientIp;
 
   StartStudyTimeRequestDto({
-    required this.startTime,
     required this.gatewayIp,
     required this.clientIp,
   });
 
   Map<String, dynamic> toJson() {
     return {
-      "startTime": startTime.toIso8601String(),
       "gatewayIp": gatewayIp,
       "clientIp":clientIp,
     };

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -144,7 +144,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       await vm.endStudyTime(
         EndStudyRequestDto(
           studySessionId: _sessionId,
-          endTime: DateTime.now(),
         ),
       );
       print("endStudyTime 성공");
@@ -257,7 +256,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
                       final res = await vm.startStudyTime(
                         StartStudyTimeRequestDto(
-                          startTime: now,
                           gatewayIp: wifi['gatewayIp'] ?? '',
                           clientIp: wifi['ip'] ?? '',
                         ),


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 이전에 테스트 과정에서 타이머 시작 후 기기 시간을 임의로 바꾸어 학습 시간을 조작하는 상황이 있었습니다. 
- 이를 해결하기 위해 DateTime.now()를 사용하지 않고 서버 측에서 시간을 관리하도록 수정합니다.

---

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.

- [x] end_study_time_request_dto에서 endTime 삭제
- [x] start_study_time_request_dto에서 startTime삭제

---

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.
- 이전에 에러가 있던 환경에서 테스트를 진행하여 시간 조작이 가능했던 것으로 보입니다. 현재 코드로는 홈 화면으로 이탈 시 즉시 end 요청이 전송되기에 시간 조작이 무의미합니다.
- 하지만 특수한 상황에 의해 시간 조작이 발생할 수 있으므로 현재 시간 측정 부분을 서버 측으로 이전합니다.

---

## ✅ 관련 이슈

- 관련 이슈 번호: #47 
