### PR TITLE
[FIX] 랭킹 페이시 랭킹 동적으로 해당 기간 데이터 반영하도록 수정

### DIFF
--- a/lib/screens/ranking/ranking.dart
+++ b/lib/screens/ranking/ranking.dart
@@ -7,6 +7,7 @@ import 'package:geumpumta/screens/ranking/widgets/per_day_or_week_or_month.dart'
 import 'package:geumpumta/screens/ranking/widgets/ranking_board.dart';
 import 'package:geumpumta/screens/ranking/widgets/ranking_my_info.dart';
 import 'package:geumpumta/widgets/text_header/text_header.dart';
+import 'package:collection/collection.dart';
 
 import '../../viewmodel/rank/rank_personal_viewmodel.dart';
 
@@ -48,6 +49,26 @@ class _RankingScreenState extends ConsumerState<RankingScreen> {
       vm.getDailyPersonalRanking(null);
     });
   }
+
+  int? _getMyTotalMillis() {
+    final asyncState = ref.watch(rankPersonalViewModelProvider);
+    final userInfoState = ref.watch(userInfoStateProvider);
+
+    return asyncState.maybeWhen(
+      data: (response) {
+        if (response == null) return null;
+
+        final myRank = response.data.topRanks.firstWhereOrNull(
+              (e) => e.username == userInfoState?.nickName,
+        );
+
+        return myRank?.totalMillis;
+      },
+      orElse: () => null,
+    );
+  }
+
+
 
   @override
   Widget build(BuildContext context) {
@@ -102,7 +123,7 @@ class _RankingScreenState extends ConsumerState<RankingScreen> {
                 userInfoState?.profileImage ??
                 'https://i.namu.wiki/i/65UQVcoBA0aPl5FwSu5OvRT9v_B_yNBVs1VHah0ULM8ucqv95vBcMuzDDc8fb1ejGcrKNoa-IhsnMq5n7YEqwQ.webp',
             recordedTime: Duration(
-              milliseconds: userInfoState?.totalMillis ?? 0,
+              milliseconds: _getMyTotalMillis() ?? 0,
             ),
           ),
         ],


### PR DESCRIPTION
## 📌 개요

> 랭킹 페이지에서 하단에 있는 랭킹에 들어가는 정보를 수정했습니다.

---

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.

- [x] 랭킹 페이지 하단 데이터 반환하는 메서드 추가
- [x] 해당 기간 millisec로 반영
---

## ✅ 동작 이미지

| 구분 | 화면 |
| --- | --- |
| 랭킹 페이지 하단 랭킹 정보 | <img width="300" alt="랭킹 페이지 하단 랭킹 정보" src="https://github.com/user-attachments/assets/6252747f-612e-479f-abde-a898c0917721" /> |

---

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.

- 상단에 있는 랭킹 부분은 현재 당일 기록으로 나오게 됩니다만, 기록 정보가 두 개나 나오면 사용자가 조금 불편하거나 헷갈려할 수 있을 거 같아 상단에 있는 부분을 어떻게 바꿀지 고민 중입니다. 좋은 의견 있으면 공유 부탁드립니다.

---

## ✅ 관련 이슈

- 관련 이슈 번호: #51 
