### PR TITLE
[FIX] deleted 사용자 랭킹에서 표시 처리

### DIFF
--- a/lib/screens/ranking/widgets/ranking_board.dart
+++ b/lib/screens/ranking/widgets/ranking_board.dart
@@ -82,6 +82,10 @@ class _RankingBoardState extends ConsumerState<RankingBoard> {
     }
   }
 
+  String _convertDeletedNickname(String nickname){
+    return nickname.replaceAll('deleted_', '');
+  }
+
   void _fetchRanking() {
     final period = widget.periodOption;
 
@@ -156,7 +160,7 @@ class _RankingBoardState extends ConsumerState<RankingBoard> {
               dateTime: widget.selectedDate,
               ranking: data.rank,
               imgUrl: data.imageUrl,
-              nickname: data.username ?? '알 수 없음',
+              nickname: _convertDeletedNickname(data.username??'알 수 없음'),
               recordedTime: Duration(milliseconds: data.totalMillis),
               userId: data.userId,
             );


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.

- 삭제된 사용자의 랭킹 표시를 수정하였습니다.

---

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.

- [x] 삭제된 사용자의 닉네임을 올바르게 표시하도록 수정하였습니다.

---

## ✅ 동작 이미지

| 구분 | 화면 |
|------|------|
| 앱 메인 화면 | <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-03 at 15:01:30" src="https://github.com/user-attachments/assets/a40b7282-1fb6-4552-9c40-af36780566c7" /> |

---

## ✅ 관련 이슈

- 관련 이슈 번호: #62