### PR TITLE
[BUG] 1.1.2 버그 수정

### DIFF
--- a/lib/models/dto/study/get_study_time_response_dto.dart
+++ b/lib/models/dto/study/get_study_time_response_dto.dart
@@ -1,18 +1,29 @@
 class StudyTimeData {
   final int totalStudySession;
   final bool isStudying;
+  final DateTime? startTime;
 
-  StudyTimeData({required this.totalStudySession, required this.isStudying});
+  StudyTimeData({
+    required this.totalStudySession,
+    required this.isStudying,
+    required this.startTime,
+  });
 
   factory StudyTimeData.fromJson(Map<String, dynamic> json) => StudyTimeData(
     totalStudySession: json['totalStudySession'] as int,
     isStudying: _parseBool(json['isStudying']),
+    startTime: _parseDateTime(json['startTime']),
   );
 
   static bool _parseBool(dynamic value) {
     if (value is bool) return value;
     if (value is String) return value.toLowerCase() == 'true';
     return false;
+  }
+
+  static DateTime? _parseDateTime(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
   }
 }
 

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -14,6 +14,7 @@ import 'package:geumpumta/viewmodel/study/study_viewmodel.dart';
 import 'package:geumpumta/widgets/badge/unnotified_badge_modal.dart';
 import 'package:geumpumta/widgets/error_dialog/error_dialog.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../provider/study/study_provider.dart';
 import '../../provider/userState/user_info_state.dart';
@@ -29,6 +30,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   static const MethodChannel platform = MethodChannel("network_monitor");
+  static const String _studySessionIdStorageKey = 'activeStudySessionId';
 
   bool _isInitialLoading = true;
   bool _isStartingStudy = false;
@@ -43,6 +45,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Timer? _timer;
   ProviderSubscription<bool>? _studyRunningSubscription;
   int _sessionId = 0;
+
+  Future<void> _saveSessionId(int sessionId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_studySessionIdStorageKey, sessionId);
+  }
+
+  Future<void> _loadPersistedSessionId() async {
+    final prefs = await SharedPreferences.getInstance();
+    _sessionId = prefs.getInt(_studySessionIdStorageKey) ?? 0;
+  }
+
+  Future<void> _clearPersistedSessionId() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_studySessionIdStorageKey);
+  }
+
+  Future<int> _resolveSessionIdForStop() async {
+    if (_sessionId != 0) return _sessionId;
+
+    await _loadPersistedSessionId();
+    return _sessionId;
+  }
 
   void _setupNetworkListener() {
     platform.setMethodCallHandler((call) async {
@@ -83,7 +107,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       }
     });
 
-    WidgetsBinding.instance.addPostFrameCallback((_) => _refreshFromServer());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _loadPersistedSessionId();
+      await _refreshFromServer();
+    });
   }
 
   @override
@@ -99,8 +126,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final vm = ref.read(studyViewmodelProvider);
 
     try {
+      final sessionId = await _resolveSessionIdForStop();
+      if (sessionId == 0) {
+        await _refreshFromServer();
+        if (!mounted) return;
+        ErrorDialog.show(context, "진행 중인 공부 세션 정보를 찾을 수 없습니다.");
+        return;
+      }
+
       final res = await vm.endStudyTime(
-        EndStudyRequestDto(studySessionId: _sessionId),
+        EndStudyRequestDto(studySessionId: sessionId),
       );
 
       if (res == null || !res.success) {
@@ -127,6 +162,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
       ref.read(studyRunningProvider.notifier).state = false;
       _sessionId = 0;
+      await _clearPersistedSessionId();
 
       await _refreshFromServer();
       await _checkAndShowUnnotifiedBadges();
@@ -176,6 +212,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       _accumulatedDuration = Duration.zero;
       _sessionId = 0;
     });
+    await _clearPersistedSessionId();
     await _refreshFromServer();
   }
 
@@ -208,6 +245,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           _sessionId = 0;
           _timerDuration = totalDuration;
         });
+        await _clearPersistedSessionId();
         ref.read(studyRunningProvider.notifier).state = false;
       }
 
@@ -281,6 +319,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                             }
 
                             _sessionId = res.data!.studySessionId;
+                            await _saveSessionId(_sessionId);
 
                             if (defaultTargetPlatform == TargetPlatform.iOS) {
                               try {
@@ -295,7 +334,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                               _accumulatedDuration = _timerDuration;
                             });
 
-                            ref.read(studyRunningProvider.notifier).state = true;
+                            ref.read(studyRunningProvider.notifier).state =
+                                true;
 
                             _startLocalTimer();
                           } catch (e) {

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -194,8 +194,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (_sessionStartTime == null) return;
 
     setState(() {
+      final elapsed = DateTime.now().difference(_sessionStartTime!);
       _timerDuration =
-          _accumulatedDuration + DateTime.now().difference(_sessionStartTime!);
+          _accumulatedDuration + (elapsed.isNegative ? Duration.zero : elapsed);
     });
   }
 
@@ -223,18 +224,32 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
       final totalMillis = response.data.totalStudySession;
       final isStudying = response.data.isStudying;
+      final startTime = response.data.startTime;
       final totalDuration = Duration(milliseconds: totalMillis);
 
       if (!mounted) return;
 
       if (isStudying) {
-        setState(() {
-          _isTimerRunning = true;
-          _accumulatedDuration = totalDuration;
-          _sessionStartTime = DateTime.now();
-          _timerDuration = totalDuration;
-        });
-        _startLocalTimer();
+        if (startTime != null) {
+          final elapsed = DateTime.now().difference(startTime);
+          final safeElapsed = elapsed.isNegative ? Duration.zero : elapsed;
+
+          setState(() {
+            _isTimerRunning = true;
+            _accumulatedDuration = totalDuration;
+            _sessionStartTime = startTime;
+            _timerDuration = totalDuration + safeElapsed;
+          });
+          _startLocalTimer();
+        } else {
+          _stopLocalTimer();
+          setState(() {
+            _isTimerRunning = false;
+            _accumulatedDuration = totalDuration;
+            _sessionStartTime = null;
+            _timerDuration = totalDuration;
+          });
+        }
         ref.read(studyRunningProvider.notifier).state = true;
       } else {
         _stopLocalTimer();


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.

- 타이머 시작 후 앱 종료 후에 다시 접속해도 타이머의 시간이 현재 진행중인 공부 시간과 같도록 수정
- SharedPreference를 사용하여 타이머 시작 후 앱 종료 후 다시 접속해도 타이머의 종료가 가능하도록 수정

---

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.

- [x] 공부 시간 조회 api 수정사항에 맞게 시작시간 api에서 받아와 반영하도록 수정
- [x] 타이머 시작 값 SharedPreference로 저장하여 앱 종료해도 남아있도록 수정


---

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.

- 코드로 확인하시면 될 거 같습니다. 특이사항은 없습니다.

---

## ✅ 관련 이슈

- 관련 이슈 번호: #87 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 학습 세션 ID가 기기에 저장되어 앱 재시작 후에도 진행 중인 세션이 복구됩니다.
  * 서버 정보와 로컬 타이머를 동기화하여 더 정확한 경과 시간 계산을 제공합니다.

* **Bug Fixes**
  * 음수 경과 시간이 표시되는 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->