### PR TITLE
[FIX] 백엔드 측 로그인 로직 수정사항 반영

### DIFF
--- a/lib/core/auth/auth_session_manager.dart
+++ b/lib/core/auth/auth_session_manager.dart
@@ -1,0 +1,75 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../routes/app_routes.dart';
+import '../../widgets/common_dialog/common_dialog.dart';
+import '../navigation/app_navigator.dart';
+
+class AuthSessionManager {
+  static bool _isHandlingSessionExpiry = false;
+  static const String _defaultSessionExpiryMessage = '로그인 세션이 유효하지 않습니다.';
+  static Future<void> Function()? onSessionCleared;
+
+  static Future<void> clearLocalSession({bool clearFcmToken = false}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('accessToken');
+    await prefs.remove('refreshToken');
+    await prefs.remove('userInfo');
+
+    if (clearFcmToken) {
+      try {
+        if (Firebase.apps.isEmpty) {
+          await Firebase.initializeApp();
+        }
+        await FirebaseMessaging.instance.deleteToken();
+      } catch (_) {
+        // FCM cleanup failure should not block local logout.
+      }
+    }
+
+    await onSessionCleared?.call();
+  }
+
+  static Future<void> handleSessionExpiry({
+    String? message,
+    String title = '로그인이 필요합니다',
+    bool showDialog = false,
+  }) async {
+    if (_isHandlingSessionExpiry) {
+      return;
+    }
+    _isHandlingSessionExpiry = true;
+
+    await clearLocalSession(clearFcmToken: true);
+
+    final nav = rootNavigatorKey.currentState;
+    if (nav == null) {
+      _isHandlingSessionExpiry = false;
+      return;
+    }
+
+    nav.pushNamedAndRemoveUntil(AppRoutes.login, (route) => false);
+
+    if (!showDialog) {
+      _isHandlingSessionExpiry = false;
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final context = rootNavigatorKey.currentContext;
+      if (context != null) {
+        CommonDialog.show(
+          context,
+          title: title,
+          message: (message == null || message.trim().isEmpty)
+              ? _defaultSessionExpiryMessage
+              : message.trim(),
+          confirmText: '로그인하기',
+        );
+      }
+      _isHandlingSessionExpiry = false;
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,9 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:geumpumta/provider/userState/user_info_state.dart';
 import 'package:geumpumta/provider/notification/fcm_provider.dart';
 import 'package:geumpumta/provider/repository_provider.dart';
+import 'package:geumpumta/provider/signin/signin_provider.dart';
 import 'package:geumpumta/provider/study/study_provider.dart';
+import 'package:geumpumta/core/auth/auth_session_manager.dart';
 import 'package:geumpumta/core/navigation/app_navigator.dart';
 import 'package:geumpumta/screens/login/login.dart';
 import 'package:geumpumta/screens/main/main.dart';
@@ -71,6 +73,12 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    AuthSessionManager.onSessionCleared = () async {
+      await ref.read(userInfoStateProvider.notifier).clear();
+      ref.read(signUpProvider.notifier).reset();
+      ref.read(studyRunningProvider.notifier).state = false;
+    };
+
     final isInteractionLocked = ref.watch(appInteractionLockedProvider);
 
     return MaterialApp(

--- a/lib/service/auth/auth_service.dart
+++ b/lib/service/auth/auth_service.dart
@@ -1,13 +1,8 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:http/http.dart' as http;
-
-/// 서버가 redirect_uri?error=already_logged_in 으로 보낼 때 던지는 예외
-class AlreadyLoggedInException implements Exception {
-  @override
-  String toString() => 'AlreadyLoggedInException';
-}
 
 class OAuthService {
   String get baseUrl => dotenv.env['BASE_URL'] ?? '';
@@ -29,10 +24,8 @@ class OAuthService {
       // 서버가 error 쿼리로 리다이렉트한 경우 (중복 로그인 등)
       final errorParam = uri.queryParameters['error'];
       if (errorParam != null) {
-        print('OAuth redirect with error: $errorParam, fullUri: $result');
-        if (errorParam == 'already_logged_in') {
-          throw AlreadyLoggedInException();
-        }
+        debugPrint('OAuth redirect with error: $errorParam, fullUri: $result');
+        return null;
       }
 
       final accessToken =
@@ -55,12 +48,9 @@ class OAuthService {
         );
         return tokenData;
       }
-
       return null;
-    } on AlreadyLoggedInException {
-      rethrow;
     } catch (e) {
-      print('OAuth 로그인 실패: $e');
+      debugPrint('OAuth 로그인 실패: $e');
       return null;
     }
   }

--- a/lib/service/token_interceptor.dart
+++ b/lib/service/token_interceptor.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/auth/auth_session_manager.dart';
 import '../core/maintenance/maintenance_guard.dart';
 
 class TokenInterceptor extends Interceptor {
+  static const String _sessionInvalidCode = 'S007';
+
   final Dio dio;
   bool _isRefreshing = false;
   final List<_PendingRequest> _pendingRequests = [];
@@ -43,6 +49,39 @@ class TokenInterceptor extends Interceptor {
     }
 
     if (err.response?.statusCode == 401) {
+      final errorCode = _extractErrorCode(err.response?.data);
+      if (errorCode == _sessionInvalidCode) {
+        final prefs = await SharedPreferences.getInstance();
+        final storedAccessToken = prefs.getString('accessToken');
+        final storedRefreshToken = prefs.getString('refreshToken');
+        final requestUri = err.requestOptions.uri;
+        debugPrint(
+          '[AUTH][S007] api=${err.requestOptions.method} '
+          '${err.requestOptions.path} '
+          '(url=$requestUri)',
+        );
+        debugPrint(
+          '[AUTH][S007] response='
+          'status=${err.response?.statusCode}, '
+          'code=$errorCode, '
+          'message=${_extractErrorMessage(err.response?.data)}, '
+          'data=${err.response?.data}',
+        );
+        debugPrint(
+          '[AUTH][S007] storedTokens='
+          'access=${_maskToken(storedAccessToken)}, '
+          'refresh=${_maskToken(storedRefreshToken)}',
+        );
+
+        _isRefreshing = false;
+        _rejectPendingRequests(err);
+        await AuthSessionManager.handleSessionExpiry(
+          message: _extractErrorMessage(err.response?.data),
+          showDialog: true,
+        );
+        return handler.next(err);
+      }
+
       // 이미 갱신 중이면 대기열에 추가
       if (_isRefreshing) {
         return _addToPendingRequests(err, handler);
@@ -57,6 +96,7 @@ class TokenInterceptor extends Interceptor {
       if (refreshToken == null || oldAccessToken == null) {
         _isRefreshing = false;
         _rejectPendingRequests(err);
+        await AuthSessionManager.handleSessionExpiry();
         return handler.next(err);
       }
 
@@ -100,7 +140,7 @@ class TokenInterceptor extends Interceptor {
 
         if (newAccessToken != null) {
           await prefs.setString('accessToken', newAccessToken);
-          if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
+          if (newRefreshToken != null) {
             await prefs.setString('refreshToken', newRefreshToken);
           }
 
@@ -121,15 +161,12 @@ class TokenInterceptor extends Interceptor {
         } else {
           _isRefreshing = false;
           _rejectPendingRequests(err);
+          await AuthSessionManager.handleSessionExpiry();
         }
       } catch (e) {
-        // 토큰 갱신 실패 시 모든 토큰 삭제 (갱신 실패하면 로그아웃 처리)
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.remove('accessToken');
-        await prefs.remove('refreshToken');
-        await prefs.remove('userInfo');
         _isRefreshing = false;
         _rejectPendingRequests(err);
+        await AuthSessionManager.handleSessionExpiry();
       }
     }
 
@@ -168,6 +205,50 @@ class TokenInterceptor extends Interceptor {
       pending.handler.next(err);
     }
     _pendingRequests.clear();
+  }
+
+  String? _extractErrorCode(dynamic payload) {
+    final map = _toMap(payload);
+    return map?['code']?.toString();
+  }
+
+  String? _extractErrorMessage(dynamic payload) {
+    final map = _toMap(payload);
+    return (map?['message'] ?? map?['msg'])?.toString();
+  }
+
+  String _maskToken(String? token) {
+    if (token == null || token.isEmpty) {
+      return 'missing';
+    }
+    if (token.length <= 12) {
+      return token;
+    }
+    return '${token.substring(0, 6)}...${token.substring(token.length - 6)}';
+  }
+
+  Map<String, dynamic>? _toMap(dynamic payload) {
+    if (payload is Map<String, dynamic>) {
+      return payload;
+    }
+
+    if (payload is Map) {
+      return payload.map((key, value) => MapEntry(key.toString(), value));
+    }
+
+    if (payload is String && payload.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(payload);
+        if (decoded is Map<String, dynamic>) {
+          return decoded;
+        }
+        if (decoded is Map) {
+          return decoded.map((key, value) => MapEntry(key.toString(), value));
+        }
+      } catch (_) {}
+    }
+
+    return null;
   }
 }
 

--- a/lib/viewmodel/auth/auth_viewmodel.dart
+++ b/lib/viewmodel/auth/auth_viewmodel.dart
@@ -10,12 +10,11 @@ import '../../provider/signin/signin_provider.dart';
 import '../../provider/notification/fcm_provider.dart';
 import '../../provider/repository_provider.dart';
 import '../../repository/auth/auth_repository.dart';
-import '../../service/auth/auth_service.dart';
 import '../../repository/user/user_repository.dart';
+import '../../core/auth/auth_session_manager.dart';
 import '../../viewmodel/user/user_viewmodel.dart';
 import '../../routes/app_routes.dart';
 import '../../core/navigation/app_navigator.dart';
-import '../../widgets/error_dialog/error_dialog.dart';
 
 final authViewModelProvider = StateNotifierProvider<AuthViewModel, bool>(
   (ref) => AuthViewModel(ref),
@@ -80,6 +79,9 @@ class AuthViewModel extends StateNotifier<bool> {
         if (context.mounted) {
           final shouldRestore = await _showRestoreAccountDialog(context);
           if (shouldRestore == true) {
+            if (!context.mounted) {
+              return false;
+            }
             // 계정 복구 시도
             debugPrint('복구 다이얼로그에서 복구하기 선택됨');
             final restored = await _restoreAccount(context);
@@ -151,6 +153,9 @@ class AuthViewModel extends StateNotifier<bool> {
             if (context.mounted) {
               final shouldRestore = await _showRestoreAccountDialog(context);
               if (shouldRestore == true) {
+                if (!context.mounted) {
+                  return false;
+                }
                 // 계정 복구 시도
                 final restored = await _restoreAccount(context);
                 if (restored) {
@@ -197,17 +202,6 @@ class AuthViewModel extends StateNotifier<bool> {
 
       await _completeLogin(userInfo);
       return true;
-    } on AlreadyLoggedInException {
-      debugPrint('$provider already_logged_in 응답 수신, 저장 토큰 복구 시도');
-      final restored = await _restoreStoredSession();
-      if (!restored && context.mounted) {
-        ErrorDialog.show(
-          context,
-          '다른 계정에서 이미 로그인되어있습니다!',
-          title: '로그인할 수 없습니다!',
-        );
-      }
-      return restored;
     } catch (e, st) {
       debugPrint('$provider 로그인 중 오류: $e\n$st');
       if (context.mounted) {
@@ -233,9 +227,6 @@ class AuthViewModel extends StateNotifier<bool> {
     debugPrint("userInfo 저장 완료: $jsonString");
 
     await ref.read(fcmServiceProvider).initAndRegisterToken();
-    await ref
-        .read(fcmServiceProvider)
-        .registerCurrentTokenToServer(reason: 'after_login');
 
     final nav = rootNavigatorKey.currentState;
     if (nav == null) {
@@ -244,45 +235,8 @@ class AuthViewModel extends StateNotifier<bool> {
     if (userInfo.userRole == "GUEST") {
       nav.pushNamed(AppRoutes.signin1);
     } else {
-      nav.pushNamedAndRemoveUntil(
-        AppRoutes.main,
-        (route) => false,
-      );
+      nav.pushNamedAndRemoveUntil(AppRoutes.main, (route) => false);
     }
-  }
-
-  Future<bool> _restoreStoredSession() async {
-    final prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    if (accessToken == null || accessToken.isEmpty) {
-      return false;
-    }
-
-    try {
-      final userInfo = await ref
-          .read(userViewModelProvider.notifier)
-          .loadUserProfile();
-
-      if (userInfo == null) {
-        await _clearStoredAuth();
-        return false;
-      }
-
-      await _completeLogin(userInfo);
-      return true;
-    } catch (e, st) {
-      debugPrint('저장 세션 복구 실패: $e\n$st');
-      await _clearStoredAuth();
-      return false;
-    }
-  }
-
-  Future<void> _clearStoredAuth() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('accessToken');
-    await prefs.remove('refreshToken');
-    await prefs.remove('userInfo');
-    await ref.read(userInfoStateProvider.notifier).clear();
   }
 
   Future<void> logout(BuildContext context) async {
@@ -296,10 +250,7 @@ class AuthViewModel extends StateNotifier<bool> {
     }
 
     await ref.read(fcmServiceProvider).deleteTokenOnServer();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('accessToken');
-    await prefs.remove('refreshToken');
-    await prefs.remove('userInfo');
+    await AuthSessionManager.clearLocalSession();
     await ref.read(userInfoStateProvider.notifier).clear();
 
     final nav = rootNavigatorKey.currentState;
@@ -318,10 +269,7 @@ class AuthViewModel extends StateNotifier<bool> {
   }
 
   Future<void> cancelGuestSignup() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('accessToken');
-    await prefs.remove('refreshToken');
-    await prefs.remove('userInfo');
+    await AuthSessionManager.clearLocalSession();
     await ref.read(userInfoStateProvider.notifier).clear();
     ref.read(signUpProvider.notifier).reset();
 
@@ -342,8 +290,7 @@ class AuthViewModel extends StateNotifier<bool> {
       );
 
       // 회원탈퇴 성공 여부와 관계없이 모든 데이터 삭제
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.clear();
+      await AuthSessionManager.clearLocalSession();
       ref.read(userInfoStateProvider.notifier).clear();
       debugPrint('회원탈퇴: 로컬 데이터 삭제 완료');
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -705,7 +705,7 @@ packages:
     source: hosted
     version: "4.3.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   json_annotation: ^4.9.0
   another_flushbar: ^1.12.32
   flutter_dotenv: ^6.0.0
+  http: ^1.2.2
   network_info_plus: ^7.0.0
   flutter_svg: ^2.2.2
   url_launcher: ^6.3.1


### PR DESCRIPTION
 ## 📌 개요

  > 해당 PR에서 어떤 작업을 했는지 요약해주세요.                                                                                                                                       

  - 로그인/세션 무효화 처리 로직 정비
  - 토큰 재발급 실패 및 S007 응답 처리 추가
  - 로그인 직후 FCM 토큰 재등록 흐름 점검 및 보강
  - 재로그인 차단 로직 제거 및 세션 교체 구조 반영

  ———

  ## ✅ 작업 내용 상세

  > 주요 변경 사항을 자세히 적어주세요.                                                                                                                                                

  - [x] OAuth redirect에서 받은 accessToken, refreshToken만 저장하도록 유지
  - [x] sessionId를 별도 저장하거나 요청 헤더/body로 보내는 로직 없이 기존 구조 유지
  - [x] 기존 already_logged_in 기반 재로그인 차단 로직 제거
  - [x] 401 발생 시 기존 방식대로 /auth/token/refresh 호출하도록 유지
  - [x] refresh 응답의 refreshToken은 값이 같아도 항상 응답값으로 덮어쓰도록 처리
  - [x] refresh 실패 시 로컬 세션 삭제 후 로그인 화면으로 이동하도록 공통 세션 종료 로직 추가
  - [x] 401 + code == S007인 경우 refresh를 시도하지 않고 즉시 세션 무효화 처리
  - [x] S007일 때만 세션 무효화 안내 다이얼로그가 노출되도록 분기 정리
  - [x] 일반 refresh 실패/토큰 누락/비정상 응답은 다이얼로그 없이 로그인 화면으로만 이동하도록 수정
  - [x] 로그인 성공 후 FCM 토큰 등록이 다시 수행되도록 로그인 완료 흐름 정리
  - [x] 강제 로그아웃 시 SharedPreferences뿐 아니라 인메모리 사용자 상태/가입 상태/공부 상태도 함께 초기화되도록 보강
  - [x] 로그아웃/회원탈퇴/게스트 가입 취소 시 공통 세션 정리 로직 사용하도록 정리
  - [x] 디버깅 중 추가했던 전체 토큰 로그는 다시 마스킹 형태로 원복

  ———

  ## ✅ 동작 이미지 첨부

  > 이미지를 첨부해주세요.                                                                                                                                                             

<img width="689" height="783" alt="image" src="https://github.com/user-attachments/assets/5f212e6e-52f0-480a-b295-d49a686574b4" />
  - 필요 시 S007 발생 시점, 로그인 후 메인 진입, 강제 로그아웃 다이얼로그 동작 화면 추가 예정

  ———

  ## ✅ 참고 사항

  > 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.                                                                                                                                 

  - 현재 세션 무효화 안내 다이얼로그는 S007 응답일 때만 노출되도록 제한했습니다.
  - 로그인 자체는 성공하지만, POST /api/v1/fcm/token 호출 시 백엔드에서 S007이 반환되는 현상이 확인되었습니다.
  - 따라서 현 시점 이슈는 “로그인 실패”라기보다 “로그인 직후 FCM 토큰 등록 API가 세션 무효화 응답을 반환하는 문제”에 가깝습니다.
  - 프론트에서는 해당 상황을 추적하기 위한 인증 로그를 추가했다가, 토큰 노출 위험 때문에 다시 마스킹 상태로 복구했습니다.
  - http 패키지를 직접 import하고 있어 pubspec.yaml에 명시 의존성을 추가했습니다.

  ———

  ## ✅ 관련 이슈

  - 관련 이슈 번호: #123