### PR TITLE
[BUG] 통계 API 중복 호출 제거

### DIFF
--- a/lib/screens/main/main.dart
+++ b/lib/screens/main/main.dart
@@ -6,7 +6,6 @@ import 'package:geumpumta/widgets/badge/unnotified_badge_modal.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../provider/study/study_provider.dart';
-import '../../viewmodel/stats/grass_stats_viewmodel.dart';
 import '../../widgets/bottom_ad_banner/bottom_ad_banner.dart';
 import '../more/more.dart';
 import '../ranking/ranking.dart';
@@ -97,11 +96,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       _statsRefreshToken++;
     } else if (index == 2) {
       _rankingRefreshToken++;
-    }
-
-    // 통계 탭으로 이동할 때마다 연속공부현황 provider 새로고침
-    if (index == 1) {
-      final _ = ref.refresh(currentStreakProvider(null));
     }
 
     setState(() => _selectedIndex = index);

--- a/lib/screens/stats/stats.dart
+++ b/lib/screens/stats/stats.dart
@@ -38,8 +38,6 @@ class _StatsScreenState extends ConsumerState<StatsScreen> {
   }
 
   void _refreshSupportingData() {
-    ref.invalidate(currentStreakProvider(null));
-
     final now = DateTime.now();
     final currentMonth = DateTime(now.year, now.month, 1);
     final previousMonth = DateTime(

--- a/lib/screens/stats/widgets/continuous_study_section.dart
+++ b/lib/screens/stats/widgets/continuous_study_section.dart
@@ -33,11 +33,6 @@ class _ContinuousStudySectionState extends ConsumerState<ContinuousStudySection>
         ? DateTime(widget.selectedDate!.year, widget.selectedDate!.month)
         : DateTime.now();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.manualStreakDays == null) {
-        ref.invalidate(currentStreakProvider(widget.targetUserId));
-      }
-    });
   }
 
   @override
@@ -55,10 +50,6 @@ class _ContinuousStudySectionState extends ConsumerState<ContinuousStudySection>
       setState(() {
         _viewMonth = DateTime(newDate.year, newDate.month);
       });
-
-      if (widget.manualStreakDays == null) {
-        ref.invalidate(currentStreakProvider(widget.targetUserId));
-      }
     }
   }
 

--- a/lib/screens/stats/widgets/daily_stats_view.dart
+++ b/lib/screens/stats/widgets/daily_stats_view.dart
@@ -7,8 +7,6 @@ import 'package:geumpumta/screens/stats/widgets/motivational_message.dart';
 import 'package:geumpumta/screens/stats/widgets/stats_skeleton.dart';
 import 'package:geumpumta/screens/stats/widgets/usage_time_chart_section.dart';
 import 'package:geumpumta/viewmodel/stats/daily_stats_viewmodel.dart';
-import 'package:geumpumta/viewmodel/stats/grass_stats_viewmodel.dart';
-
 class DailyStatsView extends ConsumerStatefulWidget {
   const DailyStatsView({super.key, required this.refreshToken});
 
@@ -40,8 +38,6 @@ class _DailyStatsViewState extends ConsumerState<DailyStatsView> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fetchDailyStats();
-      // 연속공부현황 provider 새로고침
-      ref.invalidate(currentStreakProvider(null));
     });
   }
 
@@ -51,7 +47,6 @@ class _DailyStatsViewState extends ConsumerState<DailyStatsView> {
     if (oldWidget.refreshToken != widget.refreshToken) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _fetchDailyStats();
-        ref.invalidate(currentStreakProvider(null));
       });
     }
   }

--- a/lib/screens/stats/widgets/monthly_stats_view.dart
+++ b/lib/screens/stats/widgets/monthly_stats_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geumpumta/models/entity/stats/monthly_statistics.dart';
 import 'package:geumpumta/screens/stats/widgets/continuous_study_section.dart';
 import 'package:geumpumta/screens/stats/widgets/make_motivation_highlight_text.dart';
-import 'package:geumpumta/viewmodel/stats/grass_stats_viewmodel.dart';
 import 'package:geumpumta/viewmodel/stats/monthly_stats_viewmodel.dart';
 
 import '../../ranking/widgets/period_option.dart';
@@ -27,7 +26,6 @@ class _MonthlyStatsViewState extends ConsumerState<MonthlyStatsView> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fetchMonthlyStats();
-      ref.invalidate(currentStreakProvider(null));
     });
   }
 
@@ -37,7 +35,6 @@ class _MonthlyStatsViewState extends ConsumerState<MonthlyStatsView> {
     if (oldWidget.refreshToken != widget.refreshToken) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _fetchMonthlyStats();
-        ref.invalidate(currentStreakProvider(null));
       });
     }
   }

--- a/lib/screens/stats/widgets/weekly_stats_view.dart
+++ b/lib/screens/stats/widgets/weekly_stats_view.dart
@@ -4,8 +4,6 @@ import 'package:geumpumta/models/entity/stats/weekly_statistics.dart';
 import 'package:geumpumta/screens/stats/widgets/continuous_study_section.dart';
 import 'package:geumpumta/screens/stats/widgets/make_motivation_highlight_text.dart';
 import 'package:geumpumta/viewmodel/stats/weekly_stats_viewmodel.dart';
-import 'package:geumpumta/viewmodel/stats/grass_stats_viewmodel.dart';
-
 import '../../ranking/widgets/period_option.dart';
 
 class WeeklyStatsView extends ConsumerStatefulWidget {
@@ -27,7 +25,6 @@ class _WeeklyStatsViewState extends ConsumerState<WeeklyStatsView> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fetchWeeklyStats();
-      ref.invalidate(currentStreakProvider(null));
     });
   }
 
@@ -37,7 +34,6 @@ class _WeeklyStatsViewState extends ConsumerState<WeeklyStatsView> {
     if (oldWidget.refreshToken != widget.refreshToken) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _fetchWeeklyStats();
-        ref.invalidate(currentStreakProvider(null));
       });
     }
   }

--- a/lib/viewmodel/stats/grass_stats_viewmodel.dart
+++ b/lib/viewmodel/stats/grass_stats_viewmodel.dart
@@ -50,12 +50,8 @@ FutureProvider.autoDispose.family<int, (int? userId, DateTime month)>((ref, para
   final userId = params.$1;
   final selectedMonth = params.$2;
 
-  final repo = ref.watch(grassStatisticsRepositoryProvider);
-
-  final stats = await repo.fetchGrassStatistics(
-    date: _formatMonth(selectedMonth),
-    targetUserId: userId,
-  );
+  // grassStatisticsProvider 캐시 공유 - 별도 API 호출 없이 캐시된 데이터 활용
+  final stats = await ref.watch(grassStatisticsProvider((selectedMonth, userId)).future);
 
   // 해당 월의 데이터만 필터링
   final monthStart = DateTime(selectedMonth.year, selectedMonth.month, 1);
@@ -84,7 +80,6 @@ FutureProvider.autoDispose.family<int, (int? userId, DateTime month)>((ref, para
 
 
 final currentStreakProvider = FutureProvider.autoDispose.family<int, int?>((ref, targetUserId) async {
-  final repo = ref.watch(grassStatisticsRepositoryProvider);
   final today = DateTime.now();
   final currentMonth = DateTime(today.year, today.month, 1);
   final previousMonth = DateTime(
@@ -93,17 +88,12 @@ final currentStreakProvider = FutureProvider.autoDispose.family<int, int?>((ref,
     1,
   );
 
+  // grassStatisticsProvider 캐시 공유 - 별도 API 호출 없이 캐시된 데이터 활용
+  final current = await ref.watch(grassStatisticsProvider((currentMonth, targetUserId)).future);
+  final prev = await ref.watch(grassStatisticsProvider((previousMonth, targetUserId)).future);
+
   final entries = <GrassEntry>[];
-  final current = await repo.fetchGrassStatistics(
-    date: _formatMonth(currentMonth),
-    targetUserId: targetUserId,
-  );
   entries.addAll(current.entries);
-  
-  final prev = await repo.fetchGrassStatistics(
-    date: _formatMonth(previousMonth),
-    targetUserId: targetUserId,
-  );
   entries.addAll(prev.entries);
 
   final byDate = <String, int>{


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.

- 통계 탭에서의 불필요한 API 중복 호출을 제거했습니다

---

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.

**수정 전**

- `main.dart`: `currentStreakProvider(null)` refresh → grass API 2회 호출
- `StatsScreen.didChangeDependencies`: `currentStreakProvider(null)` invalidate → grass API 2회 중복 + grassStatisticsProvider 3회
- `DailyStatsView.initState`: `currentStreakProvider(null)` 또 invalidate → grass API 2회 중복
- `ContinuousStudySection.initState`: `currentStreakProvider(null)` 또 invalidate → grass API 2회 중복
- `monthlyStreakProvider watch`: 별도로 grass API 1회 중복
- 합산했을 때, `/statistics/grass` 를 최대 11회 이상 호출하는 문제

**수정 후**

- `StatsScreen.didChangeDependencies`: `grassStatisticsProvider` 3개 invalidate → grass API 정확히 3회 (현재월, 이전월, 다음월)
- `monthlyStreakProvider` → `grassStatisticsProvider` 캐시 재사용 → 0회 추가
- `currentStreakProvider` → `grassStatisticsProvider` 캐시 재사용 → 0회 추가
- `ContributionGrass` → `grassStatisticsProvider` 캐시 재사용 → 0회 추가
- 합산했을 때, `/statistics/grass` 정확히 3회 호출로 변경 (필수적인 호출만)

---

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.

- `default_ranking.dart`의 31번째 줄에서 중복이 있는데, 해당부분 제거해주시면 될 것 같습니다!
```
    WidgetsBinding.instance.addPostFrameCallback((_) {
      final vm = ref.read(rankPersonalViewModelProvider.notifier);
      vm.getDailyPersonalRanking(null);
    });
  }
```
- `details_in_modal.dart`만 한번 확인해주시면 감사하겠습니다 !!

---

## ✅ 관련 이슈

- 관련 이슈 번호: #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 통계 화면의 데이터 갱신 로직을 최적화하여 캐시 처리를 개선했습니다.
  * 월간, 주간, 일간 통계 화면의 데이터 로드 방식을 정리하여 불필요한 갱신 작업을 제거했습니다.
  * 통계 데이터 조회 시 캐시된 데이터를 더 효율적으로 활용하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->