### PR TITLE
Feature/#101 event customer center

### DIFF
--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -11,6 +11,8 @@ import 'package:geumpumta/screens/more/widgets/profile_page_screen.dart';
 import 'package:geumpumta/screens/more/widgets/activity_badge_screen.dart';
 import 'package:geumpumta/screens/board/board_list_screen.dart';
 import 'package:geumpumta/screens/board/board_detail_screen.dart';
+import 'package:geumpumta/screens/more/widgets/event_screen.dart';
+import 'package:geumpumta/screens/more/widgets/customer_center_screen.dart';
 
 class AppRoutes{
   static const String login = '/login';
@@ -25,6 +27,8 @@ class AppRoutes{
   static const String activityBadge = '/activity_badge';
   static const String boardList = '/board_list';
   static const String boardDetail = '/board_detail';
+  static const String event = '/event';
+  static const String customerCenter = '/customer_center';
 
   static Map<String, WidgetBuilder> routes = {
     login:(context) => const LoginScreen(),
@@ -55,5 +59,7 @@ class AppRoutes{
       final boardId = args?['boardId'] as int? ?? 0;
       return BoardDetailScreen(boardId: boardId);
     },
+    event : (context) => const EventScreen(),
+    customerCenter : (context) => const CustomerCenterScreen(),
   };
 }

--- a/lib/screens/more/more.dart
+++ b/lib/screens/more/more.dart
@@ -43,12 +43,12 @@ class MoreScreen extends ConsumerWidget {
                           MenuItemData(
                             title: '이벤트',
                             onTap: () =>
-                                _navigateToPlaceholder(context, '이벤트'),
+                                Navigator.pushNamed(context, AppRoutes.event),
                           ),
                           MenuItemData(
                             title: '고객센터',
                             onTap: () =>
-                                _navigateToPlaceholder(context, '고객센터'),
+                                Navigator.pushNamed(context, AppRoutes.customerCenter),
                           ),
                         ],
                       ),

--- a/lib/screens/more/widgets/customer_center_screen.dart
+++ b/lib/screens/more/widgets/customer_center_screen.dart
@@ -1,0 +1,423 @@
+import 'package:flutter/material.dart';
+import 'package:geumpumta/widgets/back_and_title/back_and_title.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class CustomerCenterScreen extends StatefulWidget {
+  const CustomerCenterScreen({super.key});
+
+  @override
+  State<CustomerCenterScreen> createState() => _CustomerCenterScreenState();
+}
+
+class _CustomerCenterScreenState extends State<CustomerCenterScreen> {
+  int? _expandedIndex;
+
+  static const _faqItems = [
+    _FaqItem(
+      question: '앱을 탈퇴하면 데이터는 어떻게 되나요?',
+      answer:
+          '회원 탈퇴 시 공부 기록, 랭킹 정보, 프로필 등 모든 데이터가 즉시 삭제되며 복구가 불가능합니다. '
+          '탈퇴 전에 필요한 데이터를 미리 백업해 두시기 바랍니다.',
+    ),
+    _FaqItem(
+      question: '스터디 타이머가 정확히 작동하지 않아요.',
+      answer:
+          '배경 앱 새로 고침을 허용하고, 배터리 절약 모드를 해제해 보세요. '
+          '앱을 완전히 종료 후 다시 실행하면 정상 작동하는 경우가 많습니다. '
+          '문제가 지속되면 아래 문의하기를 통해 알려주세요.',
+    ),
+    _FaqItem(
+      question: '랭킹은 어떻게 계산되나요?',
+      answer:
+          '랭킹은 해당 기간(일/주/월)의 총 공부 시간을 기준으로 계산됩니다. '
+          '동점자의 경우 먼저 등록된 순서로 정렬됩니다.',
+    ),
+    _FaqItem(
+      question: '배지는 어떻게 획득하나요?',
+      answer:
+          '다양한 조건을 달성하면 배지를 획득할 수 있습니다. 예를 들어 첫 공부 완료, '
+          '연속 출석 달성, 누적 공부 시간 달성 등이 있습니다. '
+          '더보기 → 활동 배지에서 모든 배지 목록을 확인하세요.',
+    ),
+    _FaqItem(
+      question: '알림이 오지 않아요.',
+      answer:
+          '기기의 설정 → 알림에서 금품타 앱의 알림 권한이 허용되어 있는지 확인해 주세요. '
+          '앱 내 알림 설정도 함께 확인해 주시기 바랍니다.',
+    ),
+    _FaqItem(
+      question: '친구와 같은 그룹에서 경쟁하려면 어떻게 하나요?',
+      answer:
+          '회원가입 시 선택한 학과/부서 기준으로 그룹이 자동으로 구성됩니다. '
+          '그룹 변경은 프로필 수정에서 가능합니다.',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            const BackAndTitle(title: '고객센터'),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildContactBanner(),
+                    const SizedBox(height: 28),
+                    _buildSectionLabel('자주 묻는 질문'),
+                    const SizedBox(height: 12),
+                    ..._faqItems.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final item = entry.value;
+                      return _buildFaqItem(
+                        index: index,
+                        item: item,
+                        isExpanded: _expandedIndex == index,
+                        onTap: () {
+                          setState(() {
+                            _expandedIndex =
+                                _expandedIndex == index ? null : index;
+                          });
+                        },
+                      );
+                    }),
+                    const SizedBox(height: 28),
+                    _buildSectionLabel('문의하기'),
+                    const SizedBox(height: 12),
+                    _buildContactCard(
+                      icon: Icons.email_outlined,
+                      title: '이메일 문의',
+                      subtitle: 'totoro7378@naver.com',
+                      onTap: () => _launchUrl(
+                        context,
+                        'mailto:totoro7378@naver.com',
+                      ),
+                    ),
+                    _buildContactCard(
+                      icon: Icons.chat_bubble_outline_rounded,
+                      title: '카카오톡 오픈채팅',
+                      subtitle: '금품타 문의방',
+                      onTap: () => _launchUrl(
+                        context,
+                        'https://open.kakao.com/o/sqASLdzi',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: Container(
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFFF5F8FF),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: const Row(
+                          children: [
+                            Icon(
+                              Icons.info_outline_rounded,
+                              size: 16,
+                              color: Color(0xFF0BAEFF),
+                            ),
+                            SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                '운영 시간: 평일 오전 10시 ~ 오후 6시\n주말 및 공휴일은 답변이 지연될 수 있습니다.',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Color(0xFF666666),
+                                  height: 1.5,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContactBanner() {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [Color(0xFF0BAEFF), Color(0xFF0071FF)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '무엇을 도와드릴까요?',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                SizedBox(height: 6),
+                Text(
+                  '아래 FAQ를 확인하거나\n직접 문의해 주세요.',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.2),
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(
+              Icons.headset_mic_rounded,
+              color: Colors.white,
+              size: 30,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(String label) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w700,
+          color: Color(0xFF333333),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFaqItem({
+    required int index,
+    required _FaqItem item,
+    required bool isExpanded,
+    required VoidCallback onTap,
+  }) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isExpanded ? const Color(0xFF0BAEFF) : const Color(0xFFEFEFEF),
+        ),
+      ),
+      child: Column(
+        children: [
+          InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Row(
+                children: [
+                  Container(
+                    width: 24,
+                    height: 24,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: isExpanded
+                          ? const Color(0xFF0BAEFF)
+                          : const Color(0xFFEFEFEF),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Text(
+                      'Q',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: isExpanded ? Colors.white : const Color(0xFF999999),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      item.question,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: isExpanded
+                            ? const Color(0xFF0BAEFF)
+                            : const Color(0xFF333333),
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    isExpanded
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: isExpanded
+                        ? const Color(0xFF0BAEFF)
+                        : const Color(0xFFCCCCCC),
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (isExpanded)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 24,
+                    height: 24,
+                    alignment: Alignment.center,
+                    decoration: const BoxDecoration(
+                      color: Color(0xFFE8F7FF),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Text(
+                      'A',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: Color(0xFF0BAEFF),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      item.answer,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        color: Color(0xFF555555),
+                        height: 1.6,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContactCard({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: const Color(0xFFEFEFEF)),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: const Color(0xFFE8F7FF),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(icon, color: const Color(0xFF0BAEFF), size: 20),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF333333),
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: Color(0xFF999999),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(
+              Icons.open_in_new_rounded,
+              color: Color(0xFFCCCCCC),
+              size: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _launchUrl(BuildContext context, String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('링크를 열 수 없습니다.'),
+            duration: const Duration(seconds: 2),
+            behavior: SnackBarBehavior.floating,
+            margin: const EdgeInsets.all(16),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            backgroundColor: const Color(0xFF333333),
+          ),
+        );
+      }
+    }
+  }
+}
+
+class _FaqItem {
+  const _FaqItem({required this.question, required this.answer});
+  final String question;
+  final String answer;
+}

--- a/lib/screens/more/widgets/event_screen.dart
+++ b/lib/screens/more/widgets/event_screen.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:geumpumta/widgets/back_and_title/back_and_title.dart';
+
+class EventScreen extends StatefulWidget {
+  const EventScreen({super.key});
+
+  @override
+  State<EventScreen> createState() => _EventScreenState();
+}
+
+class _EventScreenState extends State<EventScreen> {
+  int? _expandedIndex;
+
+  static const _events = [
+    _EventItem(
+      title: '시험기간 이벤트',
+      description:
+          '공부 시간 랭킹 TOP 8에게 상품권을 드려요!\n'
+          '🥇 1등 — 배달의민족 상품권 5만원\n'
+          '🥈 2등 — 키보드\n'
+          '🥉 3~5등 — 스타벅스 상품권 1만원\n'
+          '🎖 6~8등 — 할리스 상품권 5천원\n\n'
+          '※ 교내 kumoh-wifi 연결 상태에서만 참여 가능합니다.\n'
+          '※ 부정행위 적발 시 이벤트 대상에서 제외됩니다.',
+      period: '6월 12일(금) ~ 6월 23일(화) 자정까지',
+      status: _EventStatus.ongoing,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ongoingEvents =
+        _events.where((e) => e.status == _EventStatus.ongoing).toList();
+    final upcomingEvents =
+        _events.where((e) => e.status == _EventStatus.upcoming).toList();
+    final endedEvents =
+        _events.where((e) => e.status == _EventStatus.ended).toList();
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            const BackAndTitle(title: '이벤트'),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildBanner(),
+                    const SizedBox(height: 24),
+                    _buildSection('진행 중인 이벤트', ongoingEvents),
+                    const SizedBox(height: 24),
+                    _buildSection('예정된 이벤트', upcomingEvents),
+                    const SizedBox(height: 24),
+                    _buildSection('종료된 이벤트', endedEvents),
+                    const SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBanner() {
+    return Container(
+      width: double.infinity,
+      height: 160,
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: const LinearGradient(
+          colors: [Color(0xFF0BAEFF), Color(0xFF0071FF)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: Stack(
+        children: [
+          Positioned(
+            right: -20,
+            bottom: -20,
+            child: Container(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.1),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 20,
+            bottom: 10,
+            child: Container(
+              width: 70,
+              height: 70,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withOpacity(0.1),
+              ),
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  '금품타 이벤트',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  '다양한 이벤트에 참여하고\n특별한 혜택을 받아보세요!',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection(String label, List<_EventItem> events) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: Color(0xFF333333),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (events.isEmpty)
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+            padding: const EdgeInsets.symmetric(vertical: 20),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF8F8F8),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFEFEFEF)),
+            ),
+            child: const Center(
+              child: Text(
+                '해당 이벤트가 없습니다.',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Color(0xFFBBBBBB),
+                ),
+              ),
+            ),
+          )
+        else
+          ...events.map((event) {
+            final globalIndex = _events.indexOf(event);
+            final isExpanded = _expandedIndex == globalIndex;
+            return _buildAccordionCard(
+              event: event,
+              isExpanded: isExpanded,
+              onTap: () {
+                setState(() {
+                  _expandedIndex = isExpanded ? null : globalIndex;
+                });
+              },
+            );
+          }),
+      ],
+    );
+  }
+
+  Widget _buildAccordionCard({
+    required _EventItem event,
+    required bool isExpanded,
+    required VoidCallback onTap,
+  }) {
+    final isEnded = event.status == _EventStatus.ended;
+    final badgeColor = switch (event.status) {
+      _EventStatus.ongoing => const Color(0xFF0BAEFF),
+      _EventStatus.upcoming => const Color(0xFFFF9500),
+      _EventStatus.ended => const Color(0xFF999999),
+    };
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+      decoration: BoxDecoration(
+        color: isEnded ? const Color(0xFFF8F8F8) : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isExpanded ? badgeColor.withOpacity(0.4) : const Color(0xFFEFEFEF),
+        ),
+      ),
+      child: Column(
+        children: [
+          InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Row(
+                children: [
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: badgeColor.withOpacity(0.12),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      event.status.label,
+                      style: TextStyle(
+                        color: badgeColor,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      event.title,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: isEnded
+                            ? const Color(0xFF999999)
+                            : const Color(0xFF333333),
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    isExpanded
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: isExpanded ? badgeColor : const Color(0xFFCCCCCC),
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (isExpanded)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Divider(color: Color(0xFFEFEFEF), height: 1),
+                  const SizedBox(height: 12),
+                  Text(
+                    event.description,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: isEnded
+                          ? const Color(0xFFAAAAAA)
+                          : const Color(0xFF555555),
+                      height: 1.7,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.calendar_today_outlined,
+                        size: 12,
+                        color: isEnded
+                            ? const Color(0xFFCCCCCC)
+                            : const Color(0xFF999999),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        event.period,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: isEnded
+                              ? const Color(0xFFCCCCCC)
+                              : const Color(0xFF999999),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventItem {
+  const _EventItem({
+    required this.title,
+    required this.description,
+    required this.period,
+    required this.status,
+  });
+
+  final String title;
+  final String description;
+  final String period;
+  final _EventStatus status;
+}
+
+enum _EventStatus {
+  ongoing('진행중'),
+  upcoming('예정'),
+  ended('종료');
+
+  const _EventStatus(this.label);
+  final String label;
+}


### PR DESCRIPTION
## 📌 개요

- 이벤트 화면 구현
- 고객센터 화면 구현

---

## ✅ 작업 내용 상세

- [x] 이벤트 화면 (`event_screen.dart`) 추가
  - 상단 그라데이션 배너
  - 진행중 / 예정 / 종료 섹션으로 구분
  - 이벤트 카드 아코디언 방식 (탭 시 상세 내용 펼침)
  - 이벤트 없을 경우 빈 상태 카드 표시
- [x] 고객센터 화면 (`customer_center_screen.dart`) 추가
  - 상단 배너
  - FAQ 아코디언 (Q/A 방식)
  - 이메일 문의 / 카카오톡 오픈채팅 연결 (외부 앱으로 열기)
  - 운영 시간 안내
- [x] `app_routes.dart`에 `/event`, `/customer_center` 라우트 등록
- [x] `more.dart`에서 기존 placeholder 대신 실제 화면으로 연결

---

## ✅ 동작 이미지 첨부

| 이벤트 화면 | 고객센터 화면 |
|:--:|:--:|
| <img width="1080" height="2160" alt="Screenshot_1781495877" src="https://github.com/user-attachments/assets/c75618f4-bd83-4f3d-9738-2c5eaf1936cc" /> | <img width="1080" height="2160" alt="Screenshot_1781495883" src="https://github.com/user-attachments/assets/6006fb45-4a07-4f82-9765-c990f6f0b1d4" /> |



---

## ✅ 참고 사항

- 이벤트 데이터는 현재 하드코딩으로 관리 (추후 API 구현 후 연동으로 다시 구현해야합니다.)
- 고객센터 FAQ 항목도 현재 하드코딩 (추후 서버에서 받아올 경우 수정 필요합니다.)
- 카카오톡 오픈채팅: https://open.kakao.com/o/sqASLdzi 으로 넣어놨습니다!

---

## ✅ 관련 이슈

- 관련 이슈 번호: #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * "더보기" 메뉴에 이벤트 화면 추가 - 진행 중, 예정된, 종료된 이벤트를 아코디언 형식으로 확인 가능
  * 고객센터 화면 추가 - FAQ 아코디언과 이메일, 카카오 오픈채팅을 통한 문의 기능 제공
  * 메뉴 네비게이션 개선 - 이벤트 및 고객센터 항목이 전용 화면으로 직접 이동

<!-- end of auto-generated comment: release notes by coderabbit.ai -->