### PR TITLE
[FIX] 약관 동의 별도 페이지에서 체크박스 체크하도록 수정 

### DIFF
--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:geumpumta/screens/login/login.dart';
 import 'package:geumpumta/screens/main/main.dart';
+import 'package:geumpumta/screens/signin/sign_in_terms.dart';
 import 'package:geumpumta/screens/signin/sign_in_1.dart';
 import 'package:geumpumta/screens/signin/sign_in_2.dart';
 import 'package:geumpumta/screens/signin/sign_in_3.dart';
@@ -14,8 +15,9 @@ import 'package:geumpumta/screens/board/board_detail_screen.dart';
 import 'package:geumpumta/screens/more/widgets/event_screen.dart';
 import 'package:geumpumta/screens/more/widgets/customer_center_screen.dart';
 
-class AppRoutes{
+class AppRoutes {
   static const String login = '/login';
+  static const String signinTerms = '/signin_terms';
   static const String signin1 = '/signin1';
   static const String signin2 = '/signin2';
   static const String signin3 = '/signin3';
@@ -31,11 +33,12 @@ class AppRoutes{
   static const String customerCenter = '/customer_center';
 
   static Map<String, WidgetBuilder> routes = {
-    login:(context) => const LoginScreen(),
-    signin1:(context)=>const SignIn1Screen(),
-    signin2:(context)=>const SignIn2Screen(),
-    signin3:(context)=>const SignIn3Screen(),
-    main : (context) {
+    login: (context) => const LoginScreen(),
+    signinTerms: (context) => const SignInTermsScreen(),
+    signin1: (context) => const SignIn1Screen(),
+    signin2: (context) => const SignIn2Screen(),
+    signin3: (context) => const SignIn3Screen(),
+    main: (context) {
       final args =
           ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
       final checkUnnotifiedBadgesOnEnter =
@@ -44,22 +47,25 @@ class AppRoutes{
         checkUnnotifiedBadgesOnEnter: checkUnnotifiedBadgesOnEnter,
       );
     },
-    more : (context)=> const MoreScreen(),
-    placeholder : (context) {
-      final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?; // 타입검증 해야함
+    more: (context) => const MoreScreen(),
+    placeholder: (context) {
+      final args =
+          ModalRoute.of(context)!.settings.arguments
+              as Map<String, dynamic>?; // 타입검증 해야함
       final title = args?['title'] as String? ?? ''; // 전달받은 인자가 없더라도 안전하게 처리
       return PlaceholderScreen(title: title);
     },
-    profileEdit : (context)=> const ProfileEditScreen(),
-    profilePage : (context) => const ProfilePageScreen(),
-    activityBadge : (context) => const ActivityBadgeScreen(),
-    boardList : (context) => const BoardListScreen(),
-    boardDetail : (context) {
-      final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
+    profileEdit: (context) => const ProfileEditScreen(),
+    profilePage: (context) => const ProfilePageScreen(),
+    activityBadge: (context) => const ActivityBadgeScreen(),
+    boardList: (context) => const BoardListScreen(),
+    boardDetail: (context) {
+      final args =
+          ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
       final boardId = args?['boardId'] as int? ?? 0;
       return BoardDetailScreen(boardId: boardId);
     },
-    event : (context) => const EventScreen(),
-    customerCenter : (context) => const CustomerCenterScreen(),
+    event: (context) => const EventScreen(),
+    customerCenter: (context) => const CustomerCenterScreen(),
   };
 }

--- a/lib/screens/signin/sign_in_1.dart
+++ b/lib/screens/signin/sign_in_1.dart
@@ -23,54 +23,10 @@ class _SignIn1ScreenState extends ConsumerState<SignIn1Screen> {
   bool isEmailValid = false;
 
   @override
-  void initState() {
-    super.initState();
-    _showPrivacyPopup();
-  }
-
-  @override
   void dispose() {
     studentIdController.dispose();
     emailController.dispose();
     super.dispose();
-  }
-
-  void _showPrivacyPopup() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      showDialog(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) {
-          return AlertDialog(
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
-            ),
-            title: const Text(
-              "개인정보 수집 및 이용 안내",
-              style: TextStyle(fontWeight: FontWeight.w700, fontSize: 18),
-            ),
-            content: const Text(
-              "입력하시는 학번과 학교 이메일은\n"
-              "계정 생성과 본인 확인을 위해서만 사용되며,\n"
-              "그 외의 목적으로는 사용되지 않습니다.\n\n"
-              "확인을 눌러 계속 진행해주세요.",
-              style: TextStyle(fontSize: 15, height: 1.4),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                child: const Text(
-                  "확인",
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                ),
-              ),
-            ],
-          );
-        },
-      );
-    });
   }
 
   bool _validateEmail(String email) {

--- a/lib/screens/signin/sign_in_terms.dart
+++ b/lib/screens/signin/sign_in_terms.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geumpumta/routes/app_routes.dart';
+import 'package:geumpumta/viewmodel/auth/auth_viewmodel.dart';
+
+import '../../widgets/back_and_progress/back_and_progress.dart';
+import '../../widgets/custom_button/custom_button.dart';
+
+class SignInTermsScreen extends ConsumerStatefulWidget {
+  const SignInTermsScreen({super.key});
+
+  @override
+  ConsumerState<SignInTermsScreen> createState() => _SignInTermsScreenState();
+}
+
+class _SignInTermsScreenState extends ConsumerState<SignInTermsScreen> {
+  bool _serviceTerms = false;
+  bool _privacyTerms = false;
+  bool _schoolVerificationTerms = false;
+  bool _marketingTerms = false;
+
+  bool get _allRequiredChecked =>
+      _serviceTerms && _privacyTerms && _schoolVerificationTerms;
+
+  bool get _allChecked =>
+      _serviceTerms &&
+      _privacyTerms &&
+      _schoolVerificationTerms &&
+      _marketingTerms;
+
+  Future<void> _handleCancelSignup() async {
+    final shouldCancel = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('회원가입을 그만둘까요?'),
+          content: const Text('약관 동의를 중단하고 로그인 화면으로 돌아갑니다.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('계속하기'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('그만두기'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldCancel == true && mounted) {
+      await ref.read(authViewModelProvider.notifier).cancelGuestSignup();
+    }
+  }
+
+  void _toggleAll(bool? value) {
+    final checked = value ?? false;
+    setState(() {
+      _serviceTerms = checked;
+      _privacyTerms = checked;
+      _schoolVerificationTerms = checked;
+      _marketingTerms = checked;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (!didPop) {
+          await _handleCancelSignup();
+        }
+      },
+      child: Scaffold(
+        resizeToAvoidBottomInset: true,
+        backgroundColor: Colors.white,
+        body: SafeArea(
+          child: Column(
+            children: [
+              BackAndProgress(percent: 0, onBack: _handleCancelSignup),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(20, 24, 20, 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '약관 동의',
+                        style: TextStyle(
+                          fontSize: 30,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      const Text(
+                        '금품타 이용을 위해 필요한 약관을 확인하고 동의해주세요.',
+                        style: TextStyle(
+                          color: Color(0xFF666666),
+                          fontSize: 15,
+                          height: 1.4,
+                        ),
+                      ),
+                      const SizedBox(height: 28),
+                      _AgreementTile(
+                        title: '전체 동의',
+                        description: '필수 및 선택 약관에 모두 동의합니다.',
+                        value: _allChecked,
+                        onChanged: _toggleAll,
+                        isAllAgreement: true,
+                      ),
+                      const SizedBox(height: 12),
+                      const Divider(height: 1, color: Color(0xFFE9E9E9)),
+                      const SizedBox(height: 12),
+                      _AgreementTile(
+                        title: '서비스 이용약관 동의',
+                        description: '금품타 서비스 이용 규칙과 회원 권리 및 의무를 확인했습니다.',
+                        value: _serviceTerms,
+                        onChanged: (value) {
+                          setState(() => _serviceTerms = value ?? false);
+                        },
+                        isRequired: true,
+                      ),
+                      _AgreementTile(
+                        title: '개인정보 수집 및 이용 동의',
+                        description: '학번과 학교 이메일은 계정 생성과 본인 확인을 위해서만 사용됩니다.',
+                        value: _privacyTerms,
+                        onChanged: (value) {
+                          setState(() => _privacyTerms = value ?? false);
+                        },
+                        isRequired: true,
+                      ),
+                      _AgreementTile(
+                        title: '학교 이메일 인증 및 소속 확인 동의',
+                        description: '학교 이메일 인증을 통해 재학생 여부와 소속 학과를 확인합니다.',
+                        value: _schoolVerificationTerms,
+                        onChanged: (value) {
+                          setState(
+                            () => _schoolVerificationTerms = value ?? false,
+                          );
+                        },
+                        isRequired: true,
+                      ),
+                      _AgreementTile(
+                        title: '이벤트 및 혜택 안내 수신 동의',
+                        description: '서비스 소식, 이벤트, 혜택 안내를 받을 수 있습니다.',
+                        value: _marketingTerms,
+                        onChanged: (value) {
+                          setState(() => _marketingTerms = value ?? false);
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              CustomButton(
+                buttonText: '다음',
+                onActive: _allRequiredChecked,
+                onPressed: () {
+                  Navigator.pushNamed(context, AppRoutes.signin1);
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgreementTile extends StatelessWidget {
+  const _AgreementTile({
+    required this.title,
+    required this.description,
+    required this.value,
+    required this.onChanged,
+    this.isRequired = false,
+    this.isAllAgreement = false,
+  });
+
+  final String title;
+  final String description;
+  final bool value;
+  final ValueChanged<bool?> onChanged;
+  final bool isRequired;
+  final bool isAllAgreement;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleStyle = TextStyle(
+      color: const Color(0xFF111111),
+      fontSize: isAllAgreement ? 18 : 16,
+      fontWeight: isAllAgreement ? FontWeight.w800 : FontWeight.w700,
+    );
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => onChanged(!value),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 28,
+              height: 28,
+              child: Checkbox(
+                value: value,
+                onChanged: onChanged,
+                activeColor: const Color(0xFF0BAEFF),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  RichText(
+                    text: TextSpan(
+                      style: titleStyle,
+                      children: [
+                        TextSpan(text: title),
+                        if (!isAllAgreement) ...[
+                          TextSpan(
+                            text: isRequired ? ' (필수)' : ' (선택)',
+                            style: TextStyle(
+                              color: isRequired
+                                  ? const Color(0xFF0BAEFF)
+                                  : const Color(0xFF8A8A8A),
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    description,
+                    style: const TextStyle(
+                      color: Color(0xFF777777),
+                      fontSize: 14,
+                      height: 1.35,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/viewmodel/auth/auth_viewmodel.dart
+++ b/lib/viewmodel/auth/auth_viewmodel.dart
@@ -233,7 +233,7 @@ class AuthViewModel extends StateNotifier<bool> {
     }
 
     if (userInfo.userRole == "GUEST") {
-      nav.pushNamed(AppRoutes.signin1);
+      nav.pushNamed(AppRoutes.signinTerms);
       return;
     }
 


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.                                                                               

- 회원가입 진입 시 약관 동의 모달을 별도 약관 동의 페이지로 변경
- 필수/선택 약관을 항목별로 직접 체크한 뒤 다음 단계로 이동하도록 회원가입 플로우 수정

———

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.                                                                                        

- [x] SignInTermsScreen 신규 추가
- [x] 필수 약관 3개, 선택 약관 1개 체크 UI 구현
- [x] 필수 약관을 모두 체크해야 다음 버튼이 활성화되도록 처리
- [x] 전체 동의 체크 시 필수/선택 약관이 모두 토글되도록 구현
- [x] GUEST 로그인 후 기존 /signin1 대신 /signin_terms로 이동하도록 변경
- [x] 약관 동의 완료 시 다음 페이지인 /signin1로 이동하도록 처리
- [x] 기존 signin1 진입 시 노출되던 개인정보 안내 모달 제거
- [x] 약관 동의 화면에서 뒤로가기 시 기존 회원가입 취소 플로우와 동일하게 로그인 화면으로 복귀

———

## ✅ 동작 이미지 첨부

> 이미지를 첨부해주세요.                                                                                                     
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-24 at 13 40 50" src="https://github.com/user-attachments/assets/63f5e64a-280c-4248-a5f1-91b703b675a3" />

———

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.                                                                         

- 약관 동의 여부는 현재 클라이언트 화면 플로우에서만 검증합니다.
- 기존 회원가입 완료 API DTO에는 약관 동의 필드가 없어 서버 전송 로직은 추가하지 않았습니다.
- 변경 파일 기준 dart analyze 통과 확인했습니다.
- 전체 flutter analyze는 기존 코드베이스 warning/info로 인해 실패 상태이며, 이번 변경 파일에서는 신규 이슈가 없습니다.

———

## ✅ 관련 이슈

- 관련 이슈 번호: #103 