### PR TITLE
[FIX] 개인별 랭킹에서 학과명 표시하도록 수정 

### DIFF
--- a/lib/screens/ranking/widgets/ranking_bar.dart
+++ b/lib/screens/ranking/widgets/ranking_bar.dart
@@ -10,6 +10,7 @@ class RankingBar extends StatefulWidget {
     required this.imgUrl,
     required this.nickname,
     required this.recordedTime,
+    this.departmentName,
     this.userId,
     this.dateTime,
     this.isDetailAvailable = true,
@@ -20,6 +21,7 @@ class RankingBar extends StatefulWidget {
   final String imgUrl;
   final String nickname;
   final Duration recordedTime;
+  final String? departmentName;
   final int? userId;
   final DateTime? dateTime;
   final bool? isDetailAvailable;
@@ -52,6 +54,9 @@ class _RankingBarState extends State<RankingBar> {
     String formattedDuration = '$hours:$minutes:$seconds';
     final rankingText = widget.ranking.toString();
     final rankFontSize = _rankFontSize(widget.ranking);
+    final departmentName = widget.departmentName;
+    final hasDepartment =
+        departmentName != null && departmentName.trim().isNotEmpty;
 
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
@@ -100,6 +105,17 @@ class _RankingBarState extends State<RankingBar> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      if (hasDepartment)
+                        Text(
+                          departmentName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: Color(0xFFB0B0B0),
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
                       Text(
                         widget.nickname,
                         maxLines: 1,

--- a/lib/screens/ranking/widgets/ranking_board.dart
+++ b/lib/screens/ranking/widgets/ranking_board.dart
@@ -162,12 +162,17 @@ class _RankingBoardState extends ConsumerState<RankingBoard> {
           itemCount: list.length,
           itemBuilder: (context, index) {
             final data = list[index];
+            final departmentName = data.department == Department.none
+                ? null
+                : data.department.koreanName;
+
             return RankingBar(
               periodOption: widget.periodOption,
               dateTime: widget.selectedDate,
               ranking: data.rank,
               imgUrl: data.imageUrl,
               nickname: _convertDeletedNickname(data.username ?? '알 수 없음'),
+              departmentName: departmentName,
               recordedTime: Duration(milliseconds: data.totalMillis),
               userId: data.userId,
             );


### PR DESCRIPTION
## 📌 개요

> 해당 PR에서 어떤 작업을 했는지 요약해주세요.                                                                               

- 개인별 랭킹 위젯에 학과 정보 표시 추가
- 개인 랭킹 아이템 내 텍스트 표시 순서 조정

———

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.                                                                                        

- [x] 개인 랭킹 API 응답 DTO의 department 값을 랭킹 리스트 UI에 전달
- [x] RankingBar에 선택적 departmentName 필드 추가
- [x] 개인 랭킹 아이템에서 학과명 -> 닉네임 -> 기록 시간 순서로 표시
- [x] 학과 정보가 Department.none인 경우 학과명을 표시하지 않도록 처리
- [x] dart format 적용

———

## ✅ 동작 이미지 첨부

> 이미지를 첨부해주세요.                           
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-24 at 13 48 19" src="https://github.com/user-attachments/assets/e9ea0928-4955-4442-86c5-a2d6fb242689" />
                                                                          

———

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.                                                                         

- flutter analyze 실행 결과, 기존 프로젝트 경고/정보가 남아 있어 exit code는 1이었습니다.
- 이번 변경 파일(ranking_bar.dart, ranking_board.dart)에는 신규 analyzer 이슈가 확인되지 않았습니다.

———

## ✅ 관련 이슈

- 관련 이슈 번호: #104 