### PR TITLE
[FIX] 업데이트 존재 시 강제

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -337,42 +337,35 @@ class _MyHomePageState extends ConsumerState<MyHomePage>
         context: context,
         barrierDismissible: false,
         builder: (dialogContext) {
-          return AlertDialog(
-            title: const Text(
-              '새 업데이트가 있어요',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
-            ),
-            content: Text(
-              _latestStoreVersion == null
-                  ? '더 좋은 사용성을 위해 최신 버전으로 업데이트해 주세요.'
-                  : '최신 버전(v$_latestStoreVersion)이 출시되었습니다.\n업데이트 후 더 안정적으로 이용할 수 있어요.',
-              style: const TextStyle(fontSize: 15, height: 1.5),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(),
-                child: const Text(
-                  '나중에 하기',
-                  style: TextStyle(
-                    color: Color(0xFF888888),
-                    fontWeight: FontWeight.w600,
+          return PopScope(
+            canPop: false,
+            child: AlertDialog(
+              title: const Text(
+                '업데이트가 필요해요',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+              ),
+              content: Text(
+                _latestStoreVersion == null
+                    ? '최신 버전으로 업데이트해야 앱을 이용할 수 있어요.'
+                    : '최신 버전(v$_latestStoreVersion)이 출시되었습니다.\n업데이트 후 앱을 이용할 수 있어요.',
+                style: const TextStyle(fontSize: 15, height: 1.5),
+              ),
+              actions: [
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton(
+                    onPressed: _openStoreForUpdate,
+                    child: const Text(
+                      '업데이트 하러가기',
+                      style: TextStyle(
+                        color: Color(0xFF0BAEFF),
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
                   ),
                 ),
-              ),
-              TextButton(
-                onPressed: () async {
-                  Navigator.of(dialogContext).pop();
-                  await _openStoreForUpdate();
-                },
-                child: const Text(
-                  '업데이트 하러가기',
-                  style: TextStyle(
-                    color: Color(0xFF0BAEFF),
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-            ],
+              ],
+            ),
           );
         },
       );


### PR DESCRIPTION
## 📌 개요

> 앱 업데이트가 존재할 경우 Android/iOS에서 최초 접속 시 강제 업데이트 모달을 노출하도록 변경했습니다.                                                                      

- Android/iOS 앱 업데이트 감지 시 강제 업데이트 모달 적용
- 업데이트 모달에서 나중에 하기 제거
- 모달 닫기 및 뒤로가기 차단

———

## ✅ 작업 내용 상세

> 주요 변경 사항을 자세히 적어주세요.                                                                                                                                       

- [x] new_version_plus 업데이트 감지 결과를 기반으로 업데이트 모달 노출
- [x] 업데이트 모달의 나중에 하기 버튼 제거
- [x] barrierDismissible: false로 바깥 영역 터치 닫기 차단
- [x] PopScope(canPop: false)로 Android 뒤로가기 닫기 차단
- [x] 업데이트 버튼 클릭 시 App Store / Play Store 외부 앱으로 이동
- [x] 업데이트가 필요한 경우 앱 사용을 계속할 수 없도록 강제 업데이트 흐름 적용

———

## ✅ 동작 이미지 첨부

> 이미지를 첨부해주세요.                                                                                                                                                    

———

## ✅ 참고 사항

> 리뷰어가 알아야 할 특이사항이 있다면 작성해주세요.                                                                                                                        

- 실제 모달 노출은 App Store / Play Store에 현재 앱보다 높은 버전이 배포되어 있고, new_version_plus의 status.canUpdate가 true일 때 동작합니다.
- dart format lib/main.dart 실행 완료
- flutter analyze는 기존 코드의 warning/info 96개로 실패했으며, 이번 변경 파일 관련 신규 이슈는 확인되지 않았습니다.

———

## ✅ 관련 이슈

- 관련 이슈 번호: #105 